### PR TITLE
Bump traceur version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "extend-object": "^1.0.0",
     "loader-utils": "^0.2.3",
-    "traceur": "0.0.72"
+    "traceur": "~0.0.76"
   },
   "keywords": [
     "webpack",


### PR DESCRIPTION
Hi. I've bumped traceur version to the latest available at npm.
I also used `~` so users of the `traceur-loader` can get the latest `traceur` when it would be available (since traceur do not use semver as for now).
