### PR TITLE
Change traceur to be a peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
   "main": "index.js",
   "dependencies": {
     "extend-object": "^1.0.0",
-    "loader-utils": "^0.2.3",
-    "traceur": "0.0.72"
+    "loader-utils": "^0.2.3"
+  },
+  "peerDependencies": {
+    "traceur": "0.0.x"
   },
   "keywords": [
     "webpack",


### PR DESCRIPTION
Hi @jupl ,

I think it's better for traceur to be a peer dependency, this way traceur-loader will be able to use whatever version of traceur user has chosen to use, or defaulting to the latest 0.0.x.
